### PR TITLE
Change name of test functions

### DIFF
--- a/src/test/java/duke/task/TodoTest.java
+++ b/src/test/java/duke/task/TodoTest.java
@@ -7,14 +7,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class TodoTest {
 
     @Test
-    public void toStringTest() {
+    public void testToString() {
         //Correct String representation of the Todo.
         Todo todo = new Todo("go for run");
         assertEquals("[T][ ] go for run", todo.toString());
     }
 
     @Test
-    public void markDoneTest() {
+    public void testMarkDone() {
         //Correct String representation of the Todo after marked as done.
         Todo todo = new Todo("go for walk");
         todo.markAsDone();


### PR DESCRIPTION
Change name of test functions in TodoTest in
test folder to adhere to naming conventions.
Naming conventions help coders to focus more
on important issues than syntax and naming
standards. It is important to keep naming
standardised, hence it was changed.